### PR TITLE
Fix url in client

### DIFF
--- a/configuration-client/src/main/resources/bootstrap.yml
+++ b/configuration-client/src/main/resources/bootstrap.yml
@@ -3,6 +3,6 @@ spring:
     name: configuration-client
   cloud:
     config:
-      uri: ${vcap.services.configuration-service.credentials.uri:http://localhost:pass:[<?pdf-cr?>]8888}
+      uri: ${vcap.services.configuration-service.credentials.uri:http://localhost:8888}
 
 


### PR DESCRIPTION
### Before change:
The `configuration-client` service could not get the settings from the `configuration-service`. The client service after the launch of an emergency shut down. Error: 

> `Caused by: java.lang.IllegalStateException: Invalid URL: http://localhost:pass:[<?pdf-cr?>]8888`

### After the change:
The `configuration-client` service runs stably. The client service receives settings from `configuration-service`. The `configuration-client` service responds to the request `http://localhost:8080/project-name` with the answer `Spring Cloud`.